### PR TITLE
Simulate Team Type Coverage

### DIFF
--- a/cmd/setup_app.go
+++ b/cmd/setup_app.go
@@ -3,12 +3,15 @@ package main
 import (
 	"github.com/defry256/pokemon-helper/internal/app"
 	"github.com/defry256/pokemon-helper/internal/pokedex/v1"
+	"github.com/defry256/pokemon-helper/internal/teambuilder/v1"
 )
 
 func BuildApp() *app.App {
 	pokedex := pokedex.NewService()
+	teambuilder := teambuilder.NewService(pokedex)
 
 	return &app.App{
-		Pokedex: pokedex,
+		Pokedex:     pokedex,
+		TeamBuilder: teambuilder,
 	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,7 +1,11 @@
 package app
 
-import "github.com/defry256/pokemon-helper/internal/pokedex"
+import (
+	"github.com/defry256/pokemon-helper/internal/pokedex"
+	"github.com/defry256/pokemon-helper/internal/teambuilder"
+)
 
 type App struct {
-	Pokedex pokedex.IService
+	Pokedex     pokedex.IService
+	TeamBuilder teambuilder.IService
 }

--- a/internal/httpserver/handler/teambuilder/response.go
+++ b/internal/httpserver/handler/teambuilder/response.go
@@ -1,0 +1,12 @@
+package teambuilder
+
+import (
+	"github.com/defry256/pokemon-helper/internal/pokemon"
+	"github.com/defry256/pokemon-helper/internal/pokemontype"
+)
+
+type simulateTeamResponse struct {
+	Pokemons       []*pokemon.PokemonData `json:"pokemons"`
+	CoveredTypes   []pokemontype.IType    `json:"effective_types"`
+	UncoveredTypes []pokemontype.IType    `json:"uncovered_types"`
+}

--- a/internal/httpserver/handler/teambuilder/teambuilder.go
+++ b/internal/httpserver/handler/teambuilder/teambuilder.go
@@ -1,0 +1,44 @@
+package teambuilder
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/defry256/pokemon-helper/internal/app"
+	"github.com/defry256/pokemon-helper/internal/errors"
+	"github.com/defry256/pokemon-helper/internal/httpserver/handler"
+	"github.com/defry256/pokemon-helper/internal/httpserver/response"
+	"github.com/defry256/pokemon-helper/internal/pokemon"
+)
+
+func SimulateTeam(application *app.App) http.HandlerFunc {
+	return handler.Handle(func(w http.ResponseWriter, r *http.Request) error {
+		type payload struct {
+			Pokemons []string `json:"pokemons"`
+		}
+
+		var p *payload
+		err := json.NewDecoder(r.Body).Decode(&p)
+		if err != nil {
+			return errors.NewBadRequestError(err.Error())
+		}
+
+		pokemons := []*pokemon.PokemonData{}
+		for _, p := range p.Pokemons {
+			poke := application.Pokedex.GetPokedex(p)
+			pokemons = append(pokemons, poke)
+		}
+
+		coveredTypes, uncoveredTypes, err := application.TeamBuilder.CalculateTypeCoverage(p.Pokemons)
+		if err != nil {
+			return err
+		}
+
+		response.WithData(w, http.StatusOK, simulateTeamResponse{
+			Pokemons:       pokemons,
+			CoveredTypes:   coveredTypes,
+			UncoveredTypes: uncoveredTypes,
+		})
+		return nil
+	})
+}

--- a/internal/httpserver/routes.go
+++ b/internal/httpserver/routes.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/defry256/pokemon-helper/internal/app"
 	"github.com/defry256/pokemon-helper/internal/httpserver/handler/pokedex"
+	"github.com/defry256/pokemon-helper/internal/httpserver/handler/teambuilder"
 	"github.com/gorilla/mux"
 )
 
@@ -18,6 +19,7 @@ func HandleRoutes(a *app.App) http.Handler {
 	})
 
 	root.HandleFunc("/api/v1/pokemon/{pokemonName}", pokedex.GetPokedex(a)).Methods(http.MethodGet)
+	root.HandleFunc("/api/v1/simulate-team", teambuilder.SimulateTeam(a)).Methods(http.MethodGet)
 
 	return http.TimeoutHandler(root, 30*time.Second, "Request Timeout")
 }

--- a/internal/pokedex/v1/pokedex.go
+++ b/internal/pokedex/v1/pokedex.go
@@ -26,7 +26,10 @@ func CollyCollectorOption(c *colly.Collector) Option {
 }
 
 func defaultCollector() *colly.Collector {
-	return colly.NewCollector()
+	return colly.NewCollector(
+		colly.UserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Safari/537.36"),
+		colly.AllowURLRevisit(),
+	)
 }
 
 func NewService(options ...Option) *Service {

--- a/internal/teambuilder/interface.go
+++ b/internal/teambuilder/interface.go
@@ -1,0 +1,7 @@
+package teambuilder
+
+import "github.com/defry256/pokemon-helper/internal/pokemontype"
+
+type IService interface {
+	CalculateTypeCoverage(pokemonNames []string) (coveredTypes, uncoveredTypes []pokemontype.IType, err error)
+}

--- a/internal/teambuilder/v1/teambuilder.go
+++ b/internal/teambuilder/v1/teambuilder.go
@@ -1,0 +1,76 @@
+package teambuilder
+
+import (
+	"fmt"
+
+	"github.com/defry256/pokemon-helper/internal/errors"
+	"github.com/defry256/pokemon-helper/internal/pokedex"
+	"github.com/defry256/pokemon-helper/internal/pokemontype"
+)
+
+type Service struct {
+	pokedex pokedex.IService
+}
+
+func NewService(pokedexService pokedex.IService) *Service {
+	return &Service{pokedexService}
+}
+
+func (s *Service) CalculateTypeCoverage(pokemonNames []string) (typeCovered, typeUncovered []pokemontype.IType, err error) {
+	typeCovered = []pokemontype.IType{}
+	for _, pokemonName := range pokemonNames {
+		pokemonData := s.pokedex.GetPokedex(pokemonName)
+		if pokemonData == nil {
+			return nil, nil, errors.NewNotFoundError(fmt.Sprintf("Pokemon %s not found", pokemonName))
+		}
+		for _, pokemonType := range pokemonData.Types {
+			typeCovered = append(typeCovered, pokemonType.StrongAgainst()...)
+		}
+	}
+
+	typeUncovered = getUncoveredType(typeCovered)
+
+	return typeCovered, typeUncovered, err
+}
+
+func getUncoveredType(typeCovered []pokemontype.IType) []pokemontype.IType {
+	uncoveredMap := getTypesMap()
+
+	for _, t := range typeCovered {
+		_, ok := uncoveredMap[t]
+		if ok {
+			delete(uncoveredMap, t)
+		}
+	}
+
+	uncoveredTypes := []pokemontype.IType{}
+	for _, v := range uncoveredMap {
+		uncoveredTypes = append(uncoveredTypes, v)
+	}
+
+	return uncoveredTypes
+}
+
+func getTypesMap() map[pokemontype.IType]pokemontype.IType {
+	types := map[pokemontype.IType]pokemontype.IType{
+		pokemontype.NormalType:   pokemontype.NormalType,
+		pokemontype.FireType:     pokemontype.FireType,
+		pokemontype.WaterType:    pokemontype.WaterType,
+		pokemontype.ElectricType: pokemontype.ElectricType,
+		pokemontype.GrassType:    pokemontype.GrassType,
+		pokemontype.IceType:      pokemontype.IceType,
+		pokemontype.FightingType: pokemontype.FightingType,
+		pokemontype.PoisonType:   pokemontype.PoisonType,
+		pokemontype.GroundType:   pokemontype.GroundType,
+		pokemontype.FlyingType:   pokemontype.FlyingType,
+		pokemontype.PsychicType:  pokemontype.PsychicType,
+		pokemontype.BugType:      pokemontype.BugType,
+		pokemontype.RockType:     pokemontype.RockType,
+		pokemontype.GhostType:    pokemontype.GhostType,
+		pokemontype.DragonType:   pokemontype.DragonType,
+		pokemontype.DarkType:     pokemontype.DarkType,
+		pokemontype.SteelType:    pokemontype.SteelType,
+		pokemontype.FairyType:    pokemontype.FairyType,
+	}
+	return types
+}

--- a/test/teambuilder/teambuilder_test.go
+++ b/test/teambuilder/teambuilder_test.go
@@ -1,0 +1,79 @@
+package teambuilder_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/defry256/pokemon-helper/internal/pokedex/v1"
+	"github.com/defry256/pokemon-helper/internal/pokemontype"
+	iteambuilder "github.com/defry256/pokemon-helper/internal/teambuilder"
+	"github.com/defry256/pokemon-helper/internal/teambuilder/v1"
+)
+
+func setupService() iteambuilder.IService {
+	pokedex := pokedex.NewService()
+	service := teambuilder.NewService(pokedex)
+	return service
+}
+
+func equalTypes(types1 []pokemontype.IType, types2 []pokemontype.IType, typesName string) error {
+	if len(types1) != len(types2) {
+		return fmt.Errorf("Length of %s is not match (%d != %d)", typesName, len(types1), len(types2))
+	}
+
+	for _, type1 := range types1 {
+		notMatch := true
+		for _, type2 := range types2 {
+			if type1 == type2 {
+				notMatch = false
+			}
+		}
+		if notMatch {
+			return fmt.Errorf("Type %s is not found on expected", type1)
+		}
+	}
+
+	return nil
+}
+
+func TestTeamBuilder(test *testing.T) {
+	pokemonNames := []string{"gengar", "machamp"}
+	expectedCoveredTypes := []pokemontype.IType{
+		pokemontype.PsychicType,
+		pokemontype.GhostType,
+		pokemontype.GrassType,
+		pokemontype.FairyType,
+		pokemontype.NormalType,
+		pokemontype.IceType,
+		pokemontype.RockType,
+		pokemontype.DarkType,
+		pokemontype.SteelType,
+	}
+	expectedUncoveredTypes := []pokemontype.IType{
+		pokemontype.BugType,
+		pokemontype.DragonType,
+		pokemontype.ElectricType,
+		pokemontype.FightingType,
+		pokemontype.FireType,
+		pokemontype.FlyingType,
+		pokemontype.GroundType,
+		pokemontype.PoisonType,
+		pokemontype.WaterType,
+	}
+
+	service := setupService()
+	coveredTypes, uncoveredTypes, err := service.CalculateTypeCoverage(pokemonNames)
+	if err != nil {
+		test.Fatal(err)
+	}
+
+	err = equalTypes(coveredTypes, expectedCoveredTypes, "coveredTypes")
+	if err != nil {
+		test.Fatal(err)
+	}
+
+	err = equalTypes(uncoveredTypes, expectedUncoveredTypes, "uncoveredTypes")
+	if err != nil {
+		test.Fatal(err)
+	}
+}


### PR DESCRIPTION
An endpoint for simulate team. The endpoint returns the types that will be super effective when attacked by the team's Pokémon types